### PR TITLE
Feat/coldstandby enchancement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-batch'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -35,6 +33,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.kafka:spring-kafka'
 }
 

--- a/src/main/java/ravo/ravobackend/coldStandbyBackup/backup/BackupStrategy.java
+++ b/src/main/java/ravo/ravobackend/coldStandbyBackup/backup/BackupStrategy.java
@@ -1,5 +1,6 @@
 package ravo.ravobackend.coldStandbyBackup.backup;
 
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import ravo.ravobackend.coldStandbyBackup.domain.BackupTarget;
 
 import java.nio.file.Path;
@@ -8,7 +9,7 @@ public interface BackupStrategy {
 
     boolean support(String driverClassName);
 
-    BackupTarget buildBackupTarget(String jdbcUrl, String username, String password, String driverClassName);
+    BackupTarget buildBackupTarget(DataSourceProperties dataSourceProperties);
 
     void backup(BackupTarget backupTarget, Path backupDir) throws Exception;
 }

--- a/src/main/java/ravo/ravobackend/coldStandbyBackup/backup/DumpBackupTasklet.java
+++ b/src/main/java/ravo/ravobackend/coldStandbyBackup/backup/DumpBackupTasklet.java
@@ -5,7 +5,10 @@ import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.stereotype.Component;
 import ravo.ravobackend.coldStandbyBackup.domain.BackupTarget;
 
@@ -19,24 +22,16 @@ public class DumpBackupTasklet implements Tasklet {
     @Value("${backup.output-dir}")
     private String outputDir;
 
-    @Value("${spring.datasource.active.jdbc-url}")
-    private String jdbcUrl;
-
-    @Value("${spring.datasource.active.username}")
-    private String username;
-
-    @Value("${spring.datasource.active.password}")
-    private String password;
-
-    @Value("${spring.datasource.active.driver-class-name}")
-    private String driverClassName;
+    @Autowired
+    @Qualifier("activeDataSourceProperties")
+    private DataSourceProperties dataSourceProperties;
 
     private final BackupStrategyFactory factory;
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        BackupStrategy backupStrategy = factory.getBackupStrategy(driverClassName);
-        BackupTarget backupTarget = backupStrategy.buildBackupTarget(jdbcUrl, username, password, driverClassName);
+        BackupStrategy backupStrategy = factory.getBackupStrategy(dataSourceProperties.getDriverClassName());
+        BackupTarget backupTarget = backupStrategy.buildBackupTarget(dataSourceProperties);
         Path dumpPath = Paths.get(outputDir);
         backupStrategy.backup(backupTarget, dumpPath);
 

--- a/src/main/java/ravo/ravobackend/coldStandbyBackup/backup/MySqlBackupStrategy.java
+++ b/src/main/java/ravo/ravobackend/coldStandbyBackup/backup/MySqlBackupStrategy.java
@@ -1,8 +1,10 @@
 package ravo.ravobackend.coldStandbyBackup.backup;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.stereotype.Component;
 import ravo.ravobackend.coldStandbyBackup.domain.BackupTarget;
+import ravo.ravobackend.global.util.JdbcUrlParser;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -21,19 +23,20 @@ public class MySqlBackupStrategy implements BackupStrategy {
     }
 
     @Override
-    public BackupTarget buildBackupTarget(String jdbcUrl, String username, String password, String driverClassName) {
-        // MySQL URL: jdbc:mysql://host:port/db?params
-        String core = jdbcUrl.substring("jdbc:mysql://".length()).split("\\?")[0];
-        String[] parts = core.split("/", 2);
-        String[] hp = parts[0].split(":", 2);
-        String host = hp[0];
-        String port = hp.length > 1 ? hp[1] : "3306";
-        String databaseName = parts.length > 1 ? parts[1] : "";
+    public BackupTarget buildBackupTarget(DataSourceProperties props) {
+
+        String jdbcUrl = props.getUrl();
+        String username = props.getUsername();
+        String password = props.getPassword();
+        String driverClassName = props.getDriverClassName();
+
+        // 2) JDBC URL 파싱
+        JdbcUrlParser.ParsedResult parsed = JdbcUrlParser.parse(jdbcUrl);
 
         return BackupTarget.builder()
-                .host(host)
-                .port(port)
-                .databaseName(databaseName)
+                .host(parsed.getHost())
+                .port(parsed.getPort())
+                .databaseName(parsed.getDatabaseName())
                 .username(username)
                 .password(password)
                 .driverClassName(driverClassName)

--- a/src/main/java/ravo/ravobackend/coldStandbyRecovery/controller/ColdStandbyApiController.java
+++ b/src/main/java/ravo/ravobackend/coldStandbyRecovery/controller/ColdStandbyApiController.java
@@ -2,16 +2,18 @@ package ravo.ravobackend.coldStandbyRecovery.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import ravo.ravobackend.coldStandbyRecovery.controller.request.DumpFileDto;
 import ravo.ravobackend.coldStandbyRecovery.controller.request.RecoveryRequest;
 import ravo.ravobackend.coldStandbyRecovery.service.ColdStandbyRecoveryService;
 
+import java.io.IOException;
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
-public class ColdStandbyRecoveryController {
+@RequestMapping("/api/recovery")
+public class ColdStandbyApiController {
 
     private final ColdStandbyRecoveryService recoveryService;
 

--- a/src/main/java/ravo/ravobackend/coldStandbyRecovery/controller/ColdStandbyApiController.java
+++ b/src/main/java/ravo/ravobackend/coldStandbyRecovery/controller/ColdStandbyApiController.java
@@ -17,7 +17,13 @@ public class ColdStandbyApiController {
 
     private final ColdStandbyRecoveryService recoveryService;
 
-    @PostMapping("/api/recovery")
+    @GetMapping
+    public ResponseEntity<List<DumpFileDto>> listDumps() throws IOException {
+        List<DumpFileDto> dumps = recoveryService.listDumpFiles();
+        return ResponseEntity.ok(dumps);
+    }
+
+    @PostMapping
     public ResponseEntity<String> recover(@RequestBody RecoveryRequest request) throws Exception {
         recoveryService.recover(request.getFileName());
         return ResponseEntity.ok("recovery success : " + request.getFileName());

--- a/src/main/java/ravo/ravobackend/coldStandbyRecovery/controller/ColdStandbyController.java
+++ b/src/main/java/ravo/ravobackend/coldStandbyRecovery/controller/ColdStandbyController.java
@@ -1,0 +1,54 @@
+package ravo.ravobackend.coldStandbyRecovery.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import ravo.ravobackend.coldStandbyRecovery.controller.request.DumpFileDto;
+import ravo.ravobackend.coldStandbyRecovery.service.ColdStandbyRecoveryService;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/recovery")
+public class ColdStandbyController {
+
+    private final ColdStandbyRecoveryService recoveryService;
+
+    @GetMapping
+    public String showRecoveryPage(Model model) throws IOException {
+        List<DumpFileDto> dumps;
+        dumps = recoveryService.listDumpFiles();
+        log.info("showRecovery page");
+        log.info("dumps: {}", dumps);
+        model.addAttribute("dumps", dumps);
+        return "recovery/index";
+    }
+
+    @PostMapping
+    public String recoverByForm(@RequestParam("filename") String filename, Model model) throws Exception {
+        if (filename == null || filename.isBlank()) {
+            model.addAttribute("errorMessage", "선택된 파일명이 없습니다.");
+            return "recovery/index";
+        }
+        recoveryService.recover(filename.trim());
+        model.addAttribute("successMessage", "복구 작업이 시작되었습니다: " + filename);
+
+        List<DumpFileDto> dumps = recoveryService.listDumpFiles();
+        model.addAttribute("dumps", dumps);
+        return "recovery/index";
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleError(Exception ex) {
+        return ResponseEntity
+                .status(500)
+                .body("Failed to recovery: " + ex.getMessage());
+    }
+
+}

--- a/src/main/java/ravo/ravobackend/coldStandbyRecovery/controller/request/DumpFileDto.java
+++ b/src/main/java/ravo/ravobackend/coldStandbyRecovery/controller/request/DumpFileDto.java
@@ -1,0 +1,10 @@
+package ravo.ravobackend.coldStandbyRecovery.controller.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class DumpFileDto {
+    private String filename;
+}

--- a/src/main/java/ravo/ravobackend/coldStandbyRecovery/recovery/DumpRecoveryTasklet.java
+++ b/src/main/java/ravo/ravobackend/coldStandbyRecovery/recovery/DumpRecoveryTasklet.java
@@ -6,7 +6,10 @@ import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.stereotype.Component;
 import ravo.ravobackend.coldStandbyRecovery.domain.RecoveryTarget;
 
@@ -23,17 +26,9 @@ public class DumpRecoveryTasklet implements Tasklet {
     @Value("${backup.output-dir}")
     private String backupDir;
 
-    @Value("${spring.datasource.active.jdbc-url}")
-    private String jdbcUrl;
-
-    @Value("${spring.datasource.active.username}")
-    private String username;
-
-    @Value("${spring.datasource.active.password}")
-    private String password;
-
-    @Value("${spring.datasource.active.driver-class-name}")
-    private String driverClassName;
+    @Autowired
+    @Qualifier("activeDataSourceProperties")
+    private DataSourceProperties dataSourceProperties;
 
     private final RecoveryStrategyFactory factory;
 
@@ -59,8 +54,8 @@ public class DumpRecoveryTasklet implements Tasklet {
         log.info("Starting recovery from dump file: {}", dumpPath);
 
         // 3) 전략 결정 및 RecoveryTarget 생성
-        RecoveryStrategy strategy = factory.getRecoveryStrategy(driverClassName);
-        RecoveryTarget target = strategy.buildRecoveryTarget(jdbcUrl, username, password, driverClassName);
+        RecoveryStrategy strategy = factory.getRecoveryStrategy(dataSourceProperties.getDriverClassName());
+        RecoveryTarget target = strategy.buildRecoveryTarget(dataSourceProperties);
 
         // 4) 복구 실행
         strategy.recover(target, dumpPath);

--- a/src/main/java/ravo/ravobackend/coldStandbyRecovery/recovery/RecoveryStrategy.java
+++ b/src/main/java/ravo/ravobackend/coldStandbyRecovery/recovery/RecoveryStrategy.java
@@ -1,5 +1,6 @@
 package ravo.ravobackend.coldStandbyRecovery.recovery;
 
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import ravo.ravobackend.coldStandbyRecovery.domain.RecoveryTarget;
 
 import java.nio.file.Path;
@@ -8,7 +9,7 @@ public interface RecoveryStrategy {
 
     boolean support(String driverClassName);
 
-    RecoveryTarget buildRecoveryTarget(String jdbcUrl, String username, String password, String driverClassName);
+    RecoveryTarget buildRecoveryTarget(DataSourceProperties dataSourceProperties);
 
     void recover(RecoveryTarget recoveryTarget, Path dumpFile) throws Exception;
 }

--- a/src/main/java/ravo/ravobackend/coldStandbyRecovery/service/ColdStandbyRecoveryService.java
+++ b/src/main/java/ravo/ravobackend/coldStandbyRecovery/service/ColdStandbyRecoveryService.java
@@ -4,7 +4,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import ravo.ravobackend.coldStandbyRecovery.controller.request.DumpFileDto;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -13,6 +22,9 @@ public class ColdStandbyRecoveryService {
     private final JobLauncher jobLauncher;
 
     private final Job coldStandbyRecoveryJob;
+
+    @Value("${backup.output-dir}")
+    private String dumpFolderPath;
 
     public void recover(String fileName) throws Exception {
         long ts = System.currentTimeMillis();
@@ -23,4 +35,21 @@ public class ColdStandbyRecoveryService {
                         .toJobParameters()
         );
     }
+
+    public List<DumpFileDto> listDumpFiles() throws IOException {
+        Path dumpDir = Paths.get(dumpFolderPath);
+        if (!Files.exists(dumpDir) || !Files.isDirectory(dumpDir)) {
+            throw new IOException("Dump directory not found: " + dumpFolderPath);
+        }
+
+        try {
+            return Files.list(dumpDir)
+                    .filter(Files::isRegularFile)
+                    .map(path -> new DumpFileDto(path.getFileName().toString()))
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new IOException("Failed to read dump folder: " + e.getMessage(), e);
+        }
+    }
+
 }

--- a/src/main/java/ravo/ravobackend/global/util/JdbcUrlParser.java
+++ b/src/main/java/ravo/ravobackend/global/util/JdbcUrlParser.java
@@ -1,0 +1,99 @@
+package ravo.ravobackend.global.util;
+
+public class JdbcUrlParser {
+
+    public static class ParsedResult {
+        private final String host;
+        private final String port;
+        private final String databaseName;
+
+        public ParsedResult(String host, String port, String databaseName) {
+            this.host = host;
+            this.port = port;
+            this.databaseName = databaseName;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public String getPort() {
+            return port;
+        }
+
+        public String getDatabaseName() {
+            return databaseName;
+        }
+    }
+
+    /**
+     * 주어진 JDBC URL에서 host, port, databaseName을 꺼내 반환한다.
+     *
+     * @param jdbcUrl "jdbc:<subprotocol>://host[:port]/database[?<...>]" 형태의 문자열
+     * @return host, port, databaseName을 담은 ParsedResult 객체
+     * @throws IllegalArgumentException URL 형식이 예상과 다를 경우
+     */
+    public static ParsedResult parse(String jdbcUrl) {
+        if (jdbcUrl == null || !jdbcUrl.startsWith("jdbc:")) {
+            throw new IllegalArgumentException("올바른 JDBC URL이 아닙니다: " + jdbcUrl);
+        }
+
+        // 1) "jdbc:" 이후부터 "://"까지 건너뛰기
+        int idxProtocol = jdbcUrl.indexOf("://");
+        if (idxProtocol < 0) {
+            throw new IllegalArgumentException("JDBC URL에 '://' 구분자가 없습니다: " + jdbcUrl);
+        }
+        // "jdbc:subprotocol" 부분은 무시 → "://" 바로 뒤부터 파싱 시작
+        String afterSlashSlash = jdbcUrl.substring(idxProtocol + 3); // host[:port]/dbName?...
+
+        // 2) 파라미터(?) 또는 세미콜론(;) 구분자 이전 부분만 가져오기
+        //    예: "localhost:3306/mydb?useSSL=false" → "localhost:3306/mydb"
+        //    SQLServer처럼 세미콜론을 사용하는 경우도 대비: "server:1433;databaseName=..."
+        int idxParam = indexOfFirst(afterSlashSlash, '?', ';');
+        String core = idxParam >= 0
+                ? afterSlashSlash.substring(0, idxParam)
+                : afterSlashSlash;
+
+        // 3) "/" 기준으로 "호스트[:포트]" 와 "데이터베이스 이름" 분리
+        String hostPortPart;
+        String dbPart;
+        int idxSlash = core.indexOf('/');
+        if (idxSlash < 0) {
+            // "/"가 없다면 호스트 정보만 있고, 데이터베이스 이름은 비어있다고 간주
+            hostPortPart = core;
+            dbPart = "";
+        } else {
+            hostPortPart = core.substring(0, idxSlash);
+            dbPart = core.substring(idxSlash + 1);
+        }
+
+        // 4) "호스트[:포트]"를 ":"로 분리
+        String host;
+        String port;
+        int idxColon = hostPortPart.indexOf(':');
+        if (idxColon < 0) {
+            host = hostPortPart;
+            port = null; // URL에 포트가 명시되지 않았으면 null
+        } else {
+            host = hostPortPart.substring(0, idxColon);
+            port = hostPortPart.substring(idxColon + 1);
+        }
+
+        // 5) 최종 데이터베이스 이름
+        String databaseName = dbPart == null ? "" : dbPart;
+
+        return new ParsedResult(host, port, databaseName);
+    }
+
+    /**
+     * 주어진 문자열에서 첫 번째로 등장하는 문자 idx를 찾되, 둘 다 없는 경우 -1 반환.
+     */
+    private static int indexOfFirst(String source, char a, char b) {
+        int idxA = source.indexOf(a);
+        int idxB = source.indexOf(b);
+        if (idxA < 0) return idxB;
+        if (idxB < 0) return idxA;
+        return Math.min(idxA, idxB);
+    }
+}
+

--- a/src/main/resources/templates/recovery/index.html
+++ b/src/main/resources/templates/recovery/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <title>Cold-Standby Recovery (Thymeleaf)</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 40px;
+        }
+        h1 {
+            margin-bottom: 20px;
+        }
+        #recoverBtn {
+            padding: 6px 12px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 3px;
+            cursor: pointer;
+        }
+        #recoverBtn:disabled {
+            background-color: #ccc;
+            cursor: default;
+        }
+        .message {
+            margin-top: 20px;
+            font-weight: bold;
+        }
+        .error {
+            color: red;
+        }
+        .success {
+            color: green;
+        }
+    </style>
+</head>
+<body>
+<h1>Cold-Standby Recovery</h1>
+
+<!-- 에러/성공 메시지 표시 -->
+<div th:if="${errorMessage}" class="message error" th:text="${errorMessage}"></div>
+<div th:if="${successMessage}" class="message success" th:text="${successMessage}"></div>
+
+<!-- 덤프 파일 선택 폼 -->
+<form th:action="@{/recovery/submit}" method="post">
+    <label for="filename">덤프 파일 선택:</label>
+    <select id="filename" name="filename">
+        <option value="">-- 덤프 파일을 선택하세요 --</option>
+        <!-- dumps는 Controller가 넘겨준 List<DumpFileDto> -->
+        <option th:each="dump : ${dumps}"
+                th:value="${dump.filename}"
+                th:text="${dump.filename}">
+        </option>
+    </select>
+    <button id="recoverBtn" type="submit" th:disabled="${#lists.isEmpty(dumps)}">
+        복구 시작
+    </button>
+</form>
+</body>
+</html>

--- a/src/test/java/ravo/ravobackend/coldStandbyRecovery/controller/ColdStandbyRecoveryControllerTest.java
+++ b/src/test/java/ravo/ravobackend/coldStandbyRecovery/controller/ColdStandbyRecoveryControllerTest.java
@@ -18,7 +18,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 
-@WebMvcTest(ColdStandbyRecoveryController.class)
+@WebMvcTest(ColdStandbyApiController.class)
 class ColdStandbyRecoveryControllerTest {
 
     @Autowired

--- a/src/test/java/ravo/ravobackend/coldStandbyRecovery/recovery/ColdStandbyRecoveryJobTest.java
+++ b/src/test/java/ravo/ravobackend/coldStandbyRecovery/recovery/ColdStandbyRecoveryJobTest.java
@@ -52,7 +52,7 @@ public class ColdStandbyRecoveryJobTest {
     @BeforeEach
     void setupMock() throws Exception {
         given(factory.getRecoveryStrategy(any())).willReturn(mockStrategy);
-        given(mockStrategy.buildRecoveryTarget(any(),any(),any(),any())).willReturn(mockTarget);
+        given(mockStrategy.buildRecoveryTarget(any())).willReturn(mockTarget);
         given(mockTarget.getDatabaseName()).willReturn("testDB");
         willDoNothing().given(mockStrategy).recover(any(),any());
     }

--- a/src/test/java/ravo/ravobackend/coldStandbyRecovery/recovery/MySqlRecoveryStrategyTest.java
+++ b/src/test/java/ravo/ravobackend/coldStandbyRecovery/recovery/MySqlRecoveryStrategyTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
@@ -24,19 +26,12 @@ class MySqlRecoveryStrategyTest {
     private MySqlRecoveryStrategy strategy;
 
     @Autowired
+    @Qualifier("activeJdbcTemplate")
     private JdbcTemplate jdbcTemplate;
 
-    @Value("${spring.datasource.active.jdbc-url}")
-    private String jdbcUrl;
-
-    @Value("${spring.datasource.active.username}")
-    private String username;
-
-    @Value("${spring.datasource.active.password}")
-    private String password;
-
-    @Value("${spring.datasource.active.driver-class-name}")
-    private String driverClassName;
+    @Autowired
+    @Qualifier("activeDataSourceProperties")
+    private DataSourceProperties dataSourceProperties;
 
     @Value("${backup.output-dir}")
     private String dumpDir;
@@ -67,7 +62,7 @@ class MySqlRecoveryStrategyTest {
         Files.writeString(dumpFile, sql);
         assertTrue(Files.exists(dumpFile), "덤프 파일이 생성되어야 합니다.");
 
-        RecoveryTarget recoveryTarget = strategy.buildRecoveryTarget(jdbcUrl, username, password, driverClassName);
+        RecoveryTarget recoveryTarget = strategy.buildRecoveryTarget(dataSourceProperties);
 
         //when
         strategy.recover(recoveryTarget, dumpFile);


### PR DESCRIPTION
## 요약(Summary)
- JPA, H2 불필요 라이브러리 의존성 제거 
- Dump file 리스트를 조회하고, 선택하여 Recovery 를 진행할 수 있는 기능 추가
- View Controller 추가(기존 Controller는 ApiController로 분리)
  - `/recovery` , `/api/recovery`  
- DataSourceProperties 를 사용해 DB 정보 추출하도록 리펙토링

## 변경 사항(Changes)
### 불필요 라이브러리 의존성 제거
DataSourceProperties 를 Bean으로 등록하고 사용하도록 하는 과정에서 JPA TransactionManager 관련 오류가 발생해서, 방지 차원에서 의존성 삭제하였습니다. 그게 원인은 아니라서 있어도 작동하긴 하는데, 일단은 프로젝트에서 H2, JPA를 사용하지 않으니 제거했습니다.

### DataSourceProperties 사용
기존 코드는 String type으로 url, username 등을 `@Value`를 사용해 직접 추출하여 사용하였음
-> 코드 중복 및 타입 안정성 떨어짐
- JdbcUrlParser util class를 추가하여 공통 로직 제거
- DataSourceProperties를 각각 Bean으로 등록하고 @Qualifier를 설정하여 주입받고 사용

### Dump file list 조회 및 복구
하루에 여러번 coldstandby backup을 진행할 수도 있다고 판단하여 기존 파일 형식처럼 `YYYYDDHHmmss` 형식을 유지하되, 존재하는 파일을 조회하고 선택하여 요청할 수 있도록 UI 개선

## 리뷰 요구사항
테스트 통과 확인부탁드립니다. yml파일을 리펙토링 과정에서 계속 수정했는데, 혹시 기존과 다를 수 있어서 테스트 실패 시 형식 참고해주세요.
```
spring:
  datasource:
    batch:
      jdbc-url: 
      username:
      password: 
      driver-class-name: com.mysql.cj.jdbc.Driver
    active:
      url: 
      username:
      password: 
      driver-class-name: com.mysql.cj.jdbc.Driver
    standby:
      url:
      username: 
      password: 
      driver-class-name: com.mysql.cj.jdbc.Driver

  kafka:
    bootstrap-servers: 
    consumer:
      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
      auto-offset-reset: earliest

  batch:
    jdbc:
      initialize-schema: always
    job:
      enabled: false

management:
  endpoints:
    web:
      exposure:
        include: "*"

backup:
  output-dir: # 덤프 파일 저장 디렉토리
  cron: "0 0 2 * * *"   # 매일 새벽 2시

```
## View Controller 실행 예시
### `/recovery`
![image](https://github.com/user-attachments/assets/923539b5-ca36-4c6f-bb96-3c6551e8f147)

### 복구 요청 결과
```
2025-06-01T15:53:28.742+09:00  INFO 41136 --- [nio-8080-exec-3] r.r.c.recovery.MySqlRecoveryStrategy     : Recovery completed from C:\Users\kkb00\study\ravo\RAVO-Backend\dump\ravo_db_cold_20250531235200.sql
2025-06-01T15:53:28.745+09:00  INFO 41136 --- [nio-8080-exec-3] r.r.c.recovery.DumpRecoveryTasklet       : Recovery completed successfully for database: ravo_db
2025-06-01T15:53:28.756+09:00  INFO 41136 --- [nio-8080-exec-3] o.s.batch.core.step.AbstractStep         : Step: [dumpRecoveryStep] executed in 9s290ms
2025-06-01T15:53:28.767+09:00  INFO 41136 --- [nio-8080-exec-3] o.s.b.c.l.s.TaskExecutorJobLauncher      : Job: [FlowJob: [name=coldStandbyRecoveryJob]] completed with the following parameters: [{'dumpFile':'{value=ravo_db_cold_20250531235200.sql, type=class java.lang.String, identifying=true}','ts':'{value=1748760799382, type=class java.lang.Long, identifying=true}'}] and the following status: [COMPLETED] in 9s318ms
```

![image](https://github.com/user-attachments/assets/6e0146b5-cbbe-4f56-ba9a-7d3ff3f64588)

