### PR TITLE
[FIX] InvalidPathException: Illegal char <:>, 파일 경로 설정 오류 해결

### DIFF
--- a/src/main/java/ravo/ravobackend/coldStandbyBackup/tasklet/BinlogBackupTasklet.java
+++ b/src/main/java/ravo/ravobackend/coldStandbyBackup/tasklet/BinlogBackupTasklet.java
@@ -18,6 +18,7 @@ import ravo.ravobackend.global.constants.BackupType;
 import ravo.ravobackend.global.constants.TargetDB;
 import ravo.ravobackend.global.domain.DatabaseProperties;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -63,9 +64,10 @@ public class BinlogBackupTasklet implements Tasklet {
         }
 
         GTID gtidRange = gtidRangeOpt.get();
-        String gtidRangeStr = gtidRange.toString();
-        backupDir = backupDir.resolve(gtidRangeStr.substring(gtidRangeStr.length()-10) + ".sql");
+        String gtidRangeStr = gtidRange.getStart() + "-" + gtidRange.getEnd();
+        backupDir = backupDir.resolve(gtidRangeStr + ".sql");
 
+        Files.createDirectories(backupDir.getParent());
         //첫번째 binlog 파일명 조회
         String firstBinlogFile = binlogQueryService.getFirstBinlogFile();
 

--- a/src/main/java/ravo/ravobackend/coldStandbyBackup/tasklet/DirectoryInitializerTasklet.java
+++ b/src/main/java/ravo/ravobackend/coldStandbyBackup/tasklet/DirectoryInitializerTasklet.java
@@ -37,7 +37,7 @@ public class DirectoryInitializerTasklet implements Tasklet {
         Files.createDirectories(dumpPath); // NIO 기반, 예외 발생 시 IOException
 
         String ts = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
-        Path backupFilePath = dumpPath.resolve(props.getDatabase() + "_cold_" + ts + ".sql");
+        Path backupFilePath = dumpPath.resolve(props.getDatabase() + "_" + ts);
 
         // ExecutionContext에는 문자열로 저장
         jobContext.putString(BACKUP_OUT_FILE, backupFilePath.toAbsolutePath().toString());

--- a/src/main/java/ravo/ravobackend/coldStandbyBackup/tasklet/DumpBackupTasklet.java
+++ b/src/main/java/ravo/ravobackend/coldStandbyBackup/tasklet/DumpBackupTasklet.java
@@ -13,6 +13,7 @@ import ravo.ravobackend.coldStandbyBackup.backup.BackupStrategyFactory;
 import ravo.ravobackend.global.constants.BackupType;
 import ravo.ravobackend.global.domain.DatabaseProperties;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -32,6 +33,8 @@ public class DumpBackupTasklet implements Tasklet {
         Path backupDir = Paths.get(jobContext.getString(BACKUP_OUT_FILE));
 
         BackupStrategy backupStrategy = factory.getBackupStrategy(BackupType.MYSQL_DUMP);
+        backupDir = backupDir.resolve("full.sql");
+        Files.createDirectories(backupDir.getParent());
 
         BackupRequest req = BackupRequest.builder()
                 .props(props)


### PR DESCRIPTION
#13 
- 파일 경로 지정 시 : 문자가 있으면 Invalid
- 파일 경로 생성 누락으로 백업 디렉토리를 찾지 못하는 오류